### PR TITLE
[TASK] Define typo3-cms/extension-key composer setting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
     "psr-4": {
       "SvenJuergens\\DisableBeuser\\": "Classes/"
     }
+  },
+  "extra": {
+    "typo3/cms": {
+      "extension-key": "me_backend_security"
+    }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   },
   "extra": {
     "typo3/cms": {
-      "extension-key": "me_backend_security"
+      "extension-key": "disable_beuser"
     }
   }
 }


### PR DESCRIPTION
Specifying the extension key will be mandatory in future
versions of TYPO3 (see: https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra)